### PR TITLE
Use `slice::iter` instead of `into_iter` to avoid future breakage

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -111,7 +111,7 @@ fn cargo_install(package: &str) -> std::io::Result<()> {
 fn is_executable(name: &str) -> Option<PathBuf> {
     let env_path = env::var("PATH").expect("Could not query $PATHS");
     let mut paths: Vec<PathBuf> =
-        env_path.split(|c| [';', ':'].into_iter().find(|x| **x == c).is_some())
+        env_path.split(|c| [';', ':'].iter().find(|x| **x == c).is_some())
             .map(|p| PathBuf::from(p))
             .collect();
     paths.push(env::current_dir().unwrap());


### PR DESCRIPTION
`an_array.into_iter()` currently just works because of the autoref
feature, which then calls `<[T] as IntoIterator>::into_iter`. But
in the future, arrays will implement `IntoIterator`, too. In order
to avoid problems in the future, the call is replaced by `iter()`
which is shorter and more explicit.

A crater run showed that your crate is affected by a potential future 
change. See https://github.com/rust-lang/rust/pull/65819 for more information.